### PR TITLE
[Feat] 요금제 상세 조회 API 구현 (#10)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,9 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.0'
@@ -50,12 +56,32 @@ dependencies {
     // WebClient
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
-    //jjwt
+    // jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    //querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+def generated = 'src/main/generated'
+
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+sourceSets {
+    main.java.srcDirs += [ generated ]
+}
+
+clean {
+    delete file(generated)
 }

--- a/src/main/java/com/ureca/uplait/domain/chat/entity/ChatLog.java
+++ b/src/main/java/com/ureca/uplait/domain/chat/entity/ChatLog.java
@@ -13,7 +13,7 @@ import lombok.*;
 @Builder
 public class ChatLog extends BaseEntity {
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 

--- a/src/main/java/com/ureca/uplait/domain/community/entity/Community.java
+++ b/src/main/java/com/ureca/uplait/domain/community/entity/Community.java
@@ -13,7 +13,7 @@ import lombok.*;
 @Builder
 public class Community extends BaseEntity {
 
-    @ManyToOne
-    @JoinColumn(name = "community_plan_id", nullable = false)
-    private CommunityPlan communityPlan;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "community_benefit_id", nullable = false)
+    private CommunityBenefit communityBenefit;
 }

--- a/src/main/java/com/ureca/uplait/domain/community/entity/CommunityBenefit.java
+++ b/src/main/java/com/ureca/uplait/domain/community/entity/CommunityBenefit.java
@@ -2,17 +2,20 @@ package com.ureca.uplait.domain.community.entity;
 
 import com.ureca.uplait.global.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Entity
-@Table(name="community_plan")
+@Table(name="community_benefit")
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class CommunityPlan extends BaseEntity {
+public class CommunityBenefit extends BaseEntity {
 
     @Column(nullable = false)
     private String name;
@@ -31,10 +34,4 @@ public class CommunityPlan extends BaseEntity {
 
     @Column(name = "community_condition", nullable = true)
     private String communityCondition;
-
-    @OneToMany(mappedBy = "communityPlan", cascade = CascadeType.ALL)
-    private List<CommunityPlanPrice> priceList;
-
-    @OneToMany(mappedBy = "communityPlan", cascade = CascadeType.ALL)
-    private List<Community> communities;
 }

--- a/src/main/java/com/ureca/uplait/domain/community/entity/CommunityBenefitPrice.java
+++ b/src/main/java/com/ureca/uplait/domain/community/entity/CommunityBenefitPrice.java
@@ -3,18 +3,19 @@ package com.ureca.uplait.domain.community.entity;
 import com.ureca.uplait.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Fetch;
 
 @Entity
-@Table(name = "community_plan_price")
+@Table(name = "community_benefit_price")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class CommunityPlanPrice extends BaseEntity {
+public class CommunityBenefitPrice extends BaseEntity {
 
-    @ManyToOne
-    @JoinColumn(name = "community_plan_id", nullable = false)
-    private CommunityPlan communityPlan;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "community_benefit_id", nullable = false)
+    private CommunityBenefit communityBenefit;
 
     @Column(nullable = false)
     private Integer headcount;

--- a/src/main/java/com/ureca/uplait/domain/community/entity/PlanCommunity.java
+++ b/src/main/java/com/ureca/uplait/domain/community/entity/PlanCommunity.java
@@ -1,0 +1,27 @@
+package com.ureca.uplait.domain.community.entity;
+
+import com.ureca.uplait.domain.plan.entity.Plan;
+import com.ureca.uplait.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "plan_community")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PlanCommunity extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private Plan plan;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "community_benefit_id", nullable = false)
+    private CommunityBenefit communityBenefit;
+
+}

--- a/src/main/java/com/ureca/uplait/domain/contract/entity/Contract.java
+++ b/src/main/java/com/ureca/uplait/domain/contract/entity/Contract.java
@@ -17,15 +17,15 @@ import java.time.LocalDateTime;
 @Builder
 public class Contract extends BaseEntity {
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "plan_id", nullable = false)
     private Plan plan;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "community_id", nullable = false)
     private Community community;
 

--- a/src/main/java/com/ureca/uplait/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/ureca/uplait/domain/plan/controller/PlanController.java
@@ -1,0 +1,35 @@
+package com.ureca.uplait.domain.plan.controller;
+
+import com.ureca.uplait.domain.plan.dto.response.PlanDetailResponse;
+import com.ureca.uplait.domain.plan.service.PlanService;
+import com.ureca.uplait.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/plan")
+@RestController
+@RequiredArgsConstructor
+public class PlanController {
+
+    private final PlanService planService;
+
+    /**
+     * 요금제 상세 조회
+     *
+     * @param planId
+     */
+    @Operation(summary = "요금제 상세 조회", description = "요금제 상세 조회")
+    @GetMapping("/{planId}")
+    public CommonResponse<PlanDetailResponse> getPlanDetail(
+        @Parameter(description = "요금제 id")
+        @PathVariable Long planId
+    ) {
+        return CommonResponse.success(planService.getPlanDetail(planId));
+    }
+
+}

--- a/src/main/java/com/ureca/uplait/domain/plan/dto/response/IPTVPlanDetailResponse.java
+++ b/src/main/java/com/ureca/uplait/domain/plan/dto/response/IPTVPlanDetailResponse.java
@@ -1,0 +1,22 @@
+package com.ureca.uplait.domain.plan.dto.response;
+
+import com.ureca.uplait.domain.plan.entity.IPTVPlan;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "IPTV 요금제 상세")
+public class IPTVPlanDetailResponse extends PlanDetailResponse {
+
+    @Schema(description = "채널 수", example = "213")
+    private int channel;
+
+    @Schema(description = "iptv 온라인 할인 가격", example = "13530")
+    private int iptvDiscount;
+
+    public IPTVPlanDetailResponse(IPTVPlan plan) {
+        super(plan);
+        this.channel = plan.getChannel();
+        this.iptvDiscount = plan.getIptvDiscountRate();
+    }
+}

--- a/src/main/java/com/ureca/uplait/domain/plan/dto/response/InternetPlanDetailResponse.java
+++ b/src/main/java/com/ureca/uplait/domain/plan/dto/response/InternetPlanDetailResponse.java
@@ -1,0 +1,22 @@
+package com.ureca.uplait.domain.plan.dto.response;
+
+import com.ureca.uplait.domain.plan.entity.InternetPlan;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "인터넷 요금제 상세")
+public class InternetPlanDetailResponse extends PlanDetailResponse {
+
+    @Schema(description = "인터넷 속도", example = "500M")
+    private String velocity;
+
+    @Schema(description = "인터넷 온라인 할인 가격", example = "42900")
+    private int internetDiscount;
+
+    public InternetPlanDetailResponse(InternetPlan plan) {
+        super(plan);
+        this.velocity = plan.getVelocity();
+        this.internetDiscount = plan.getInternetDiscountRate();
+    }
+}

--- a/src/main/java/com/ureca/uplait/domain/plan/dto/response/MobilePlanDetailResponse.java
+++ b/src/main/java/com/ureca/uplait/domain/plan/dto/response/MobilePlanDetailResponse.java
@@ -1,0 +1,46 @@
+package com.ureca.uplait.domain.plan.dto.response;
+
+import com.ureca.uplait.domain.plan.entity.MobilePlan;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "모바일 요금제 상세")
+public class MobilePlanDetailResponse extends PlanDetailResponse {
+
+    @Schema(description = "데이터", example = "무제한")
+    private String data;
+
+    @Schema(description = "공유 데이터", example = "테더링+쉐어링 80GB")
+    private String sharedData;
+
+    @Schema(description = "음성통화", example = "집/이동전화 무제한")
+    private String voiceCall;
+
+    @Schema(description = "문자메시지", example = "기본제공")
+    private String message;
+
+    @Schema(description = "추가 데이터", example = "월 500MB")
+    private String extraData;
+
+    @Schema(name = "미디어 혜택", example = "밀")
+    private boolean mediaBenefit;
+
+    @Schema(description = "선택 약정 할인", example = "25")
+    private int durationDiscountRate;
+
+    @Schema(description = "프리미엄 요금제 약정 할인", example = "5250")
+    private int premierDiscountRate;
+
+    public MobilePlanDetailResponse(MobilePlan plan) {
+        super(plan);
+        this.data = plan.getData();
+        this.sharedData = plan.getSharedData();
+        this.voiceCall = plan.getVoiceCall();
+        this.message = plan.getMessage();
+        this.extraData = plan.getExtraData();
+        this.mediaBenefit = plan.getMediaBenefit();
+        this.durationDiscountRate = plan.getDurationDiscountRate();
+        this.premierDiscountRate = plan.getPremierDiscountRate();
+    }
+}

--- a/src/main/java/com/ureca/uplait/domain/plan/dto/response/PlanDetailResponse.java
+++ b/src/main/java/com/ureca/uplait/domain/plan/dto/response/PlanDetailResponse.java
@@ -1,0 +1,38 @@
+package com.ureca.uplait.domain.plan.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.ureca.uplait.domain.plan.entity.Plan;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "요금제 상세 조회 결과")
+public abstract class PlanDetailResponse {
+    @Schema(description = "요금제 id", example = "1")
+    protected Long planId;
+
+    @Schema(description = "요금제 이름", example = "5G 프리미어 에센셜")
+    protected String planName;
+
+    @Schema(description = "요금제 가격", example = "59000")
+    protected Integer planPrice;
+
+    @Schema(description = "요금제 혜택", example = "U+ 모바일 TV 기본 월정액 무료")
+    protected String planBenefit;
+
+    @Schema(description = "등록 가능 여부", example = "true")
+    protected Boolean availability;
+
+    @Schema(description = "결합 가능 여부", example = "true")
+    protected Boolean combinability;
+
+    protected PlanDetailResponse(Plan plan) {
+        this.planId = plan.getId();
+        this.planName = plan.getPlanName();
+        this.planPrice = plan.getPlanPrice();
+        this.planBenefit = plan.getPlanBenefit();
+        this.availability = plan.getAvailability();
+        this.combinability = plan.getCombinability();
+    }
+}

--- a/src/main/java/com/ureca/uplait/domain/plan/dto/response/PlanResponseFactory.java
+++ b/src/main/java/com/ureca/uplait/domain/plan/dto/response/PlanResponseFactory.java
@@ -1,0 +1,24 @@
+package com.ureca.uplait.domain.plan.dto.response;
+
+import com.ureca.uplait.domain.plan.entity.IPTVPlan;
+import com.ureca.uplait.domain.plan.entity.InternetPlan;
+import com.ureca.uplait.domain.plan.entity.MobilePlan;
+import com.ureca.uplait.domain.plan.entity.Plan;
+import com.ureca.uplait.global.exception.GlobalException;
+
+import static com.ureca.uplait.global.response.ResultCode.INVALID_PLAN;
+
+public class PlanResponseFactory {
+    public static PlanDetailResponse from(Plan plan) {
+        if (plan instanceof IPTVPlan iptv) {
+            return new IPTVPlanDetailResponse(iptv);
+        } else if (plan instanceof InternetPlan internet) {
+            return new InternetPlanDetailResponse(internet);
+        } else if (plan instanceof MobilePlan mobile) {
+            return new MobilePlanDetailResponse(mobile);
+        } else {
+            throw new GlobalException(INVALID_PLAN);
+        }
+    }
+}
+

--- a/src/main/java/com/ureca/uplait/domain/plan/entity/MobilePlan.java
+++ b/src/main/java/com/ureca/uplait/domain/plan/entity/MobilePlan.java
@@ -31,7 +31,7 @@ public class MobilePlan extends Plan {
     private String extraData;
 
     @Column(name = "media_benefit", nullable = false)
-    private boolean mediaBenefit;
+    private Boolean mediaBenefit;
 
     @Column(name = "duration_discount_rate")
     private Integer durationDiscountRate;

--- a/src/main/java/com/ureca/uplait/domain/plan/entity/MobilePlan.java
+++ b/src/main/java/com/ureca/uplait/domain/plan/entity/MobilePlan.java
@@ -31,7 +31,7 @@ public class MobilePlan extends Plan {
     private String extraData;
 
     @Column(name = "media_benefit", nullable = false)
-    private String mediaBenefit;
+    private boolean mediaBenefit;
 
     @Column(name = "duration_discount_rate")
     private Integer durationDiscountRate;

--- a/src/main/java/com/ureca/uplait/domain/plan/entity/MobilePlan.java
+++ b/src/main/java/com/ureca/uplait/domain/plan/entity/MobilePlan.java
@@ -24,6 +24,15 @@ public class MobilePlan extends Plan {
     @Column(name = "voice_call", nullable = false)
     private String voiceCall;
 
+    @Column(name = "message", nullable = false)
+    private String message;
+
+    @Column(name = "extra_data", nullable = false)
+    private String extraData;
+
+    @Column(name = "media_benefit", nullable = false)
+    private String mediaBenefit;
+
     @Column(name = "duration_discount_rate")
     private Integer durationDiscountRate;
 

--- a/src/main/java/com/ureca/uplait/domain/plan/entity/Plan.java
+++ b/src/main/java/com/ureca/uplait/domain/plan/entity/Plan.java
@@ -25,12 +25,9 @@ public abstract class Plan extends BaseEntity {
     @Column(name = "plan_benefit", nullable = false)
     private String planBenefit;
 
-    @Column(name = "avaliability", nullable = false)
-    private Boolean avaliability;
+    @Column(name = "availability", nullable = false)
+    private Boolean availability;
 
-    @Column(name = "combinabiliy", nullable = false)
-    private Boolean combinabiliy;
-
-    @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL)
-    private List<Review> reviews;
+    @Column(name = "combinability", nullable = false)
+    private Boolean combinability;
 }

--- a/src/main/java/com/ureca/uplait/domain/plan/repository/PlanRepository.java
+++ b/src/main/java/com/ureca/uplait/domain/plan/repository/PlanRepository.java
@@ -1,0 +1,7 @@
+package com.ureca.uplait.domain.plan.repository;
+
+import com.ureca.uplait.domain.plan.entity.Plan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlanRepository extends JpaRepository<Plan, Long> {
+}

--- a/src/main/java/com/ureca/uplait/domain/plan/service/PlanService.java
+++ b/src/main/java/com/ureca/uplait/domain/plan/service/PlanService.java
@@ -7,6 +7,7 @@ import com.ureca.uplait.domain.plan.repository.PlanRepository;
 import com.ureca.uplait.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import static com.ureca.uplait.global.response.ResultCode.NOT_FOUND_PLAN;
 
@@ -19,6 +20,7 @@ public class PlanService {
     /**
      * 요금제 상세 조회
      */
+    @Transactional(readOnly = true)
     public PlanDetailResponse getPlanDetail(Long planId) {
         Plan plan = findPlan(planId);
         return PlanResponseFactory.from(plan);

--- a/src/main/java/com/ureca/uplait/domain/plan/service/PlanService.java
+++ b/src/main/java/com/ureca/uplait/domain/plan/service/PlanService.java
@@ -1,0 +1,30 @@
+package com.ureca.uplait.domain.plan.service;
+
+import com.ureca.uplait.domain.plan.dto.response.PlanDetailResponse;
+import com.ureca.uplait.domain.plan.dto.response.PlanResponseFactory;
+import com.ureca.uplait.domain.plan.entity.Plan;
+import com.ureca.uplait.domain.plan.repository.PlanRepository;
+import com.ureca.uplait.global.exception.GlobalException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.ureca.uplait.global.response.ResultCode.NOT_FOUND_PLAN;
+
+@Service
+@RequiredArgsConstructor
+public class PlanService {
+
+    private final PlanRepository planRepository;
+
+    /**
+     * 요금제 상세 조회
+     */
+    public PlanDetailResponse getPlanDetail(Long planId) {
+        Plan plan = findPlan(planId);
+        return PlanResponseFactory.from(plan);
+    }
+
+    private Plan findPlan(Long planId) {
+        return planRepository.findById(planId).orElseThrow(() -> new GlobalException(NOT_FOUND_PLAN));
+    }
+}

--- a/src/main/java/com/ureca/uplait/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/ureca/uplait/domain/review/controller/ReviewController.java
@@ -1,0 +1,45 @@
+package com.ureca.uplait.domain.review.controller;
+
+import com.ureca.uplait.domain.review.dto.response.ReviewDetailListResponse;
+import com.ureca.uplait.domain.review.service.ReviewService;
+import com.ureca.uplait.domain.user.entity.User;
+import com.ureca.uplait.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/review")
+@RestController
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    /**
+     * 요금제별 리뷰 전체 조회
+     *
+     * @param user 사용자 정보
+     * @param size 페이지 크기
+     * @param lastReviewId 마지막 리뷰 ID
+     * @param planId 요금제 ID
+     */
+    @Operation(summary = "요금제별 리뷰 전체 조회", description = "요금제별 리뷰 전체 조회")
+    @GetMapping("/")
+    public CommonResponse<ReviewDetailListResponse> getReviewList(
+        @Parameter(description = "사용자정보", required = true)
+        @AuthenticationPrincipal User user,
+        @Parameter(description = "한 번에 가져올 크기")
+        @RequestParam(defaultValue = "5") int size,
+        @Parameter(description = "마지막 리뷰 Id")
+        @RequestParam(required = false) Long lastReviewId,
+        @Parameter(description = "요금제 id")
+        @RequestParam Long planId
+    ) {
+        return CommonResponse.success(reviewService.getReviewList(user, size, lastReviewId, planId));
+    }
+}

--- a/src/main/java/com/ureca/uplait/domain/review/dto/response/ReviewDetailListResponse.java
+++ b/src/main/java/com/ureca/uplait/domain/review/dto/response/ReviewDetailListResponse.java
@@ -1,0 +1,17 @@
+package com.ureca.uplait.domain.review.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Schema(description = "리뷰 리스트 조회 결과")
+@AllArgsConstructor
+public class ReviewDetailListResponse {
+    @Schema(description = "리뷰List", example = "리뷰List")
+    private List<ReviewDetailResponse> reviewList;
+    @Schema(description = "다음 페이지 유무", example = "true")
+    private boolean hasNext;
+}

--- a/src/main/java/com/ureca/uplait/domain/review/dto/response/ReviewDetailResponse.java
+++ b/src/main/java/com/ureca/uplait/domain/review/dto/response/ReviewDetailResponse.java
@@ -1,0 +1,36 @@
+package com.ureca.uplait.domain.review.dto.response;
+
+import com.ureca.uplait.domain.review.entity.Review;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@Schema(description = "리뷰 조회 상세")
+public class ReviewDetailResponse {
+    @Schema(description = "리뷰 id", example = "1")
+    private Long reviewId;
+    @Schema(description = "사용자 이름", example = "유플레")
+    private String userName;
+    @Schema(description = "리뷰 작성자 여부", example = "true")
+    private boolean isAuthor;
+    @Schema(description = "리뷰 제목", example = "최고의 요금제")
+    private String title;
+    @Schema(description = "리뷰 내용", example = "가격이 싸고 속도도 빨라요.")
+    private String content;
+    @Schema(description = "별점", example = "5")
+    private int rating;
+    @Schema(description = "작성 날짜", example = "25.06.08")
+    private String createdAt;
+
+    public ReviewDetailResponse(Review review, boolean isAuthor) {
+        this.reviewId = review.getId();
+        this.userName = review.getUser().getName();
+        this.isAuthor = isAuthor;
+        this.title = review.getTitle();
+        this.content = review.getContent();
+        this.rating = review.getRating();
+        this.createdAt = review.getCreatedAt().format(DateTimeFormatter.ofPattern("yy.MM.dd"));
+    }
+}

--- a/src/main/java/com/ureca/uplait/domain/review/entity/Review.java
+++ b/src/main/java/com/ureca/uplait/domain/review/entity/Review.java
@@ -4,7 +4,10 @@ import com.ureca.uplait.domain.plan.entity.Plan;
 import com.ureca.uplait.domain.user.entity.User;
 import com.ureca.uplait.global.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "review")
@@ -14,11 +17,11 @@ import lombok.*;
 @Builder
 public class Review extends BaseEntity {
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "plan_id", nullable = false)
     private Plan plan;
 

--- a/src/main/java/com/ureca/uplait/domain/review/repository/CustomReviewRepository.java
+++ b/src/main/java/com/ureca/uplait/domain/review/repository/CustomReviewRepository.java
@@ -1,0 +1,9 @@
+package com.ureca.uplait.domain.review.repository;
+
+import com.ureca.uplait.domain.review.entity.Review;
+
+import java.util.List;
+
+public interface CustomReviewRepository {
+    List<Review> getReviewsByPlanAndPage(int size, Long lastReviewId, Long planId);
+}

--- a/src/main/java/com/ureca/uplait/domain/review/repository/CustomReviewRepositoryImpl.java
+++ b/src/main/java/com/ureca/uplait/domain/review/repository/CustomReviewRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.ureca.uplait.domain.review.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ureca.uplait.domain.review.entity.Review;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.ureca.uplait.domain.review.entity.QReview.review;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomReviewRepositoryImpl implements CustomReviewRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Review> getReviewsByPlanAndPage(int size, Long lastReviewId, Long planId) {
+        return jpaQueryFactory
+            .selectFrom(review)
+            .where(
+                ltReviewId(lastReviewId),
+                planIdEq(planId)
+            )
+            .orderBy(review.id.desc())
+            .limit(size)
+            .fetch();
+    }
+
+    private BooleanExpression ltReviewId(Long lastReviewId) {
+        if(lastReviewId == null) return null;
+        return review.id.lt(lastReviewId);
+    }
+
+    private BooleanExpression planIdEq(Long planId) {
+        if(planId == null) return null;
+        return review.plan.id.eq(planId);
+    }
+}

--- a/src/main/java/com/ureca/uplait/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/ureca/uplait/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.ureca.uplait.domain.review.repository;
+
+import com.ureca.uplait.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long>, CustomReviewRepository {
+}

--- a/src/main/java/com/ureca/uplait/domain/review/service/ReviewService.java
+++ b/src/main/java/com/ureca/uplait/domain/review/service/ReviewService.java
@@ -1,0 +1,34 @@
+package com.ureca.uplait.domain.review.service;
+
+import com.ureca.uplait.domain.review.dto.response.ReviewDetailListResponse;
+import com.ureca.uplait.domain.review.dto.response.ReviewDetailResponse;
+import com.ureca.uplait.domain.review.repository.ReviewRepository;
+import com.ureca.uplait.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+
+    /**
+     * 요금제별 리뷰 조회
+     */
+    @Transactional(readOnly = true)
+    public ReviewDetailListResponse getReviewList(User user, int size, Long lastReviewId, Long planId) {
+        List<ReviewDetailResponse> reviewDetailList = new java.util.ArrayList<>(reviewRepository.getReviewsByPlanAndPage(size + 1, lastReviewId, planId)
+            .stream().map(r -> new ReviewDetailResponse(r, r.getUser().getId() == user.getId()))
+            .toList());
+
+        // 다음 페이지 확인 및 반환값 조정
+        boolean hasNext = (reviewDetailList.size() > size);
+        if (hasNext) reviewDetailList.remove(reviewDetailList.size() - 1);
+
+        return new ReviewDetailListResponse(reviewDetailList, hasNext);
+    }
+}

--- a/src/main/java/com/ureca/uplait/domain/user/entity/Bookmark.java
+++ b/src/main/java/com/ureca/uplait/domain/user/entity/Bookmark.java
@@ -13,11 +13,11 @@ import lombok.*;
 @Builder
 public class Bookmark extends BaseEntity {
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "plan_id", nullable = false)
     private Plan plan;
 }

--- a/src/main/java/com/ureca/uplait/domain/user/entity/Interest.java
+++ b/src/main/java/com/ureca/uplait/domain/user/entity/Interest.java
@@ -12,11 +12,11 @@ import lombok.*;
 @Builder
 public class Interest extends BaseEntity {
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tag_id", nullable = false)
     private Tag tag;
 }

--- a/src/main/java/com/ureca/uplait/domain/user/entity/Tag.java
+++ b/src/main/java/com/ureca/uplait/domain/user/entity/Tag.java
@@ -17,7 +17,4 @@ public class Tag extends BaseEntity {
 
     @Column(nullable = false)
     private String name;
-
-    @OneToMany(mappedBy = "tag", cascade = CascadeType.ALL)
-    private List<Interest> interests;
 }

--- a/src/main/java/com/ureca/uplait/domain/user/entity/User.java
+++ b/src/main/java/com/ureca/uplait/domain/user/entity/User.java
@@ -50,21 +50,6 @@ public class User extends BaseEntity {
     @Column(name = "ad_agree", nullable = false)
     private Boolean adAgree;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-    private List<Bookmark> bookmarks;
-
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-    private List<Contract> contracts;
-
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-    private List<Review> reviews;
-
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-    private List<Interest> interests;
-
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-    private List<ChatLog> chatLogs;
-
     public static User createTmpUser(String kakaoId, String name){
         return User.builder()
             .kakaoId(kakaoId)

--- a/src/main/java/com/ureca/uplait/global/config/QueryDslConfig.java
+++ b/src/main/java/com/ureca/uplait/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.ureca.uplait.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/ureca/uplait/global/response/ResultCode.java
+++ b/src/main/java/com/ureca/uplait/global/response/ResultCode.java
@@ -23,8 +23,11 @@ public enum ResultCode {
     REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, 2002, "Refresh Token이 만료되었습니다."),
     ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, 2003, "Access Token이 만료되었습니다."),
     REISSUE_SUCCESS(HttpStatus.OK, 2004, "토큰 재발급에 성공했습니다. "),
-    LOGOUT_SUCCESS(HttpStatus.OK, 2005, "로그아웃에 성공했습니다.")
+    LOGOUT_SUCCESS(HttpStatus.OK, 2005, "로그아웃에 성공했습니다."),
 
+    // 요금제 3000번대
+    NOT_FOUND_PLAN(HttpStatus.NOT_FOUND, 3000, "요금제 정보를 찾을 수 없습니다."),
+    INVALID_PLAN(HttpStatus.BAD_REQUEST, 3001, "유효하지 않은 요금제 타입입니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/resources/db/changelog/2025/06/09-03-changelog.xml
+++ b/src/main/resources/db/changelog/2025/06/09-03-changelog.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.31.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+    <changeSet id="1749437209489-20" author="samsung">
+        <dropForeignKeyConstraint baseTableName="community" constraintName="fk_community_on_community_plan"/>
+    </changeSet>
+    <changeSet id="1749437209489-21" author="samsung">
+        <dropForeignKeyConstraint baseTableName="community_plan_price"
+                                  constraintName="fk_community_plan_price_on_community_plan"/>
+    </changeSet>
+    <changeSet id="1749437209489-1" author="samsung">
+        <createTable tableName="community_benefit">
+            <column autoIncrement="true" name="id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_community_benefit"/>
+            </column>
+            <column name="created_at" type="DATETIME"/>
+            <column name="updated_at" type="DATETIME"/>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="max_phone" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="max_internet" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="max_iptv" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="plan_benefit" type="VARCHAR(255)"/>
+            <column name="community_condition" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="1749437209489-2" author="samsung">
+        <createTable tableName="community_benefit_price">
+            <column autoIncrement="true" name="id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_community_benefit_price"/>
+            </column>
+            <column name="created_at" type="DATETIME"/>
+            <column name="updated_at" type="DATETIME"/>
+            <column name="community_benefit_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="headcount" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="youth_discount" type="INT"/>
+            <column name="mobile_discount" type="INT"/>
+            <column name="internet_discount" type="INT"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="1749437209489-3" author="samsung">
+        <createTable tableName="plan_community">
+            <column autoIncrement="true" name="id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_plan_community"/>
+            </column>
+            <column name="created_at" type="DATETIME"/>
+            <column name="updated_at" type="DATETIME"/>
+            <column name="plan_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="community_benefit_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet id="1749437209489-4" author="samsung">
+        <addColumn tableName="plan">
+            <column name="availability" type="BOOLEAN"/>
+            <column name="combinability" type="BOOLEAN"/>
+        </addColumn>
+    </changeSet>
+    <changeSet id="1749437209489-5" author="samsung">
+        <addNotNullConstraint columnName="availability" tableName="plan"/>
+    </changeSet>
+    <changeSet id="1749437209489-7" author="samsung">
+        <addNotNullConstraint columnName="combinability" tableName="plan"/>
+    </changeSet>
+    <changeSet id="1749437209489-8" author="samsung">
+        <addColumn tableName="community">
+            <column name="community_benefit_id" type="BIGINT"/>
+        </addColumn>
+    </changeSet>
+    <changeSet id="1749437209489-9" author="samsung">
+        <addNotNullConstraint columnName="community_benefit_id" tableName="community"/>
+    </changeSet>
+    <changeSet id="1749437209489-10" author="samsung">
+        <addColumn tableName="mobile_plan">
+            <column name="extra_data" type="VARCHAR(255)"/>
+            <column name="media_benefit" type="VARCHAR(255)"/>
+            <column name="message" type="VARCHAR(255)"/>
+        </addColumn>
+    </changeSet>
+    <changeSet id="1749437209489-11" author="samsung">
+        <addNotNullConstraint columnName="extra_data" tableName="mobile_plan"/>
+    </changeSet>
+    <changeSet id="1749437209489-13" author="samsung">
+        <addNotNullConstraint columnName="media_benefit" tableName="mobile_plan"/>
+    </changeSet>
+    <changeSet id="1749437209489-15" author="samsung">
+        <addNotNullConstraint columnName="message" tableName="mobile_plan"/>
+    </changeSet>
+    <changeSet id="1749437209489-16" author="samsung">
+        <addForeignKeyConstraint baseColumnNames="community_benefit_id" baseTableName="community_benefit_price"
+                                 constraintName="FK_COMMUNITY_BENEFIT_PRICE_ON_COMMUNITY_BENEFIT"
+                                 referencedColumnNames="id" referencedTableName="community_benefit"/>
+    </changeSet>
+    <changeSet id="1749437209489-17" author="samsung">
+        <addForeignKeyConstraint baseColumnNames="community_benefit_id" baseTableName="community"
+                                 constraintName="FK_COMMUNITY_ON_COMMUNITY_BENEFIT" referencedColumnNames="id"
+                                 referencedTableName="community_benefit"/>
+    </changeSet>
+    <changeSet id="1749437209489-18" author="samsung">
+        <addForeignKeyConstraint baseColumnNames="community_benefit_id" baseTableName="plan_community"
+                                 constraintName="FK_PLAN_COMMUNITY_ON_COMMUNITY_BENEFIT" referencedColumnNames="id"
+                                 referencedTableName="community_benefit"/>
+    </changeSet>
+    <changeSet id="1749437209489-19" author="samsung">
+        <addForeignKeyConstraint baseColumnNames="plan_id" baseTableName="plan_community"
+                                 constraintName="FK_PLAN_COMMUNITY_ON_PLAN" referencedColumnNames="id"
+                                 referencedTableName="plan"/>
+    </changeSet>
+    <changeSet id="1749437209489-22" author="samsung">
+        <dropTable cascadeConstraints="true" tableName="community_plan"/>
+    </changeSet>
+    <changeSet id="1749437209489-23" author="samsung">
+        <dropTable cascadeConstraints="true" tableName="community_plan_price"/>
+    </changeSet>
+    <changeSet id="1749437209489-24" author="samsung">
+        <dropColumn columnName="avaliability" tableName="plan"/>
+
+        <dropColumn columnName="combinabiliy" tableName="plan"/>
+    </changeSet>
+    <changeSet id="1749437209489-26" author="samsung">
+        <dropColumn columnName="community_plan_id" tableName="community"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/2025/06/09-04-changelog.xml
+++ b/src/main/resources/db/changelog/2025/06/09-04-changelog.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.31.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+    <changeSet id="1749442336444-1" author="samsung">
+        <dropColumn columnName="media_benefit" tableName="mobile_plan"/>
+    </changeSet>
+    <changeSet id="1749442336444-2" author="samsung">
+        <addColumn tableName="mobile_plan">
+            <column name="media_benefit" type="BOOLEAN">
+                <constraints nullable="false" validateNullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## ✨ 작업 내용 개요
- 요금제 상세 조회 기능 및 요금제별 리뷰 조회 기능을 구현하였습니다.

## 🛠️ 작업 사항 상세
- 더 자연스러운 리뷰 무한 스크롤을 위해 요금제 정보를 불러오는 API와 리뷰 정보를 불러오는 API를 분리하였습니다.
- no offset 형식의 리뷰 무한 스크롤을 구현할 때, lastReviewId가 null인 경우 오류가 발생하는 것을 방지하기 위해 QueryDSL을 사용하였습니다.

## 🔎 관련 이슈
- #10 

## 🕒 예상 리뷰 시간
- 15분

## ✅ PR Checklist
- [ ]  기능이 정확하게 동작합니다.
- [ ]  더 나은 코드에 대해서 고민해보았습니다.
- [ ]  구현한 기능에 대한 테스트를 진행했습니다.
- [ ]  커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ]  라벨과 리뷰어를 설정했습니다.
- [ ]  민감파일(*.yml 등) .gitignore 설정했습니다.

## 📚 참고자료

Closes #10  
